### PR TITLE
[FEAT] : 공통 Response 작성 및 예외 처리 작성

### DIFF
--- a/src/main/java/com/korailtalk/server/api/common/dto/APIErrorResponse.java
+++ b/src/main/java/com/korailtalk/server/api/common/dto/APIErrorResponse.java
@@ -1,0 +1,14 @@
+package com.korailtalk.server.api.common.dto;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public record APIErrorResponse(
+        int statusCode,
+        String message
+) {
+
+    public static ResponseEntity<APIErrorResponse> of(final HttpStatus httpStatus, final String message) {
+        return ResponseEntity.status(httpStatus).body(new APIErrorResponse(httpStatus.value(), message));
+    }
+}

--- a/src/main/java/com/korailtalk/server/api/common/dto/APISuccessResponse.java
+++ b/src/main/java/com/korailtalk/server/api/common/dto/APISuccessResponse.java
@@ -1,0 +1,13 @@
+package com.korailtalk.server.api.common.dto;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public record APISuccessResponse<T>(
+        T data
+) {
+
+    public static <T> ResponseEntity<APISuccessResponse<T>> of(final HttpStatus httpStatus, final T data) {
+        return ResponseEntity.status(httpStatus).body(new APISuccessResponse<T>(data));
+    }
+}

--- a/src/main/java/com/korailtalk/server/api/common/enums/ErrorStatus.java
+++ b/src/main/java/com/korailtalk/server/api/common/enums/ErrorStatus.java
@@ -1,0 +1,20 @@
+package com.korailtalk.server.api.common.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorStatus {
+
+    // 400 : Bad Request
+    TEST(HttpStatus.BAD_REQUEST, "test");
+    // 401 : Unauthorized
+
+    // 404 : Not Found
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+}

--- a/src/main/java/com/korailtalk/server/api/common/exception/BadRequestException.java
+++ b/src/main/java/com/korailtalk/server/api/common/exception/BadRequestException.java
@@ -1,0 +1,9 @@
+package com.korailtalk.server.api.common.exception;
+
+import com.korailtalk.server.api.common.enums.ErrorStatus;
+
+public class BadRequestException extends KorailException {
+    public BadRequestException(final ErrorStatus errorStatus) {
+        super(errorStatus);
+    }
+}

--- a/src/main/java/com/korailtalk/server/api/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/korailtalk/server/api/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,15 @@
+package com.korailtalk.server.api.common.exception;
+
+import com.korailtalk.server.api.common.dto.APIErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler({BadRequestException.class, NotFoundException.class, UnAuthorizedException.class})
+    public ResponseEntity<APIErrorResponse> handleCustomException(final KorailException korailException) {
+        return APIErrorResponse.of(korailException.getHttpStatus(), korailException.getMessage());
+    }
+}

--- a/src/main/java/com/korailtalk/server/api/common/exception/KorailException.java
+++ b/src/main/java/com/korailtalk/server/api/common/exception/KorailException.java
@@ -1,0 +1,18 @@
+package com.korailtalk.server.api.common.exception;
+
+import com.korailtalk.server.api.common.enums.ErrorStatus;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class KorailException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public KorailException(final ErrorStatus errorStatus) {
+        super(errorStatus.getMessage());
+        this.httpStatus = errorStatus.getHttpStatus();
+        this.message = errorStatus.getMessage();
+    }
+}

--- a/src/main/java/com/korailtalk/server/api/common/exception/NotFoundException.java
+++ b/src/main/java/com/korailtalk/server/api/common/exception/NotFoundException.java
@@ -1,0 +1,10 @@
+package com.korailtalk.server.api.common.exception;
+
+import com.korailtalk.server.api.common.enums.ErrorStatus;
+
+public class NotFoundException extends KorailException {
+
+    public NotFoundException(final ErrorStatus errorStatus) {
+        super(errorStatus);
+    }
+}

--- a/src/main/java/com/korailtalk/server/api/common/exception/UnAuthorizedException.java
+++ b/src/main/java/com/korailtalk/server/api/common/exception/UnAuthorizedException.java
@@ -1,0 +1,10 @@
+package com.korailtalk.server.api.common.exception;
+
+import com.korailtalk.server.api.common.enums.ErrorStatus;
+
+public class UnAuthorizedException extends KorailException {
+
+    public UnAuthorizedException(final ErrorStatus errorStatus) {
+        super(errorStatus);
+    }
+}


### PR DESCRIPTION
# ⭐️ 구현사항
<!-- Task엔 구현 내용 작성 -->
<!-- 단순한 코드 설명 X (ex : for문으로 반복, final로 불변성 보장...) -->
<!-- 링크와 함께 구현 사항 설명 (ex : Id로 회원조회, 카테고리 별로 분류...) -->

## 🔧 공통 Response 작성

🍃 요청이 성공했을 때의 Response를 작성했습니다.

https://github.com/SOPT-all/35-COLLABORATION-SERVER-KORAILTALK/blob/c461c2633fb9dca677e39a8821e671a1aa911a44/src/main/java/com/korailtalk/server/api/common/dto/APISuccessResponse.java#L6-L13

🍃 요청이 실패했을 때의 Response를 작성했습니다.

https://github.com/SOPT-all/35-COLLABORATION-SERVER-KORAILTALK/blob/c461c2633fb9dca677e39a8821e671a1aa911a44/src/main/java/com/korailtalk/server/api/common/dto/APIErrorResponse.java#L6-L14

## 🔧 예외 처리 작성

🍃 커스텀된 예외를 작성했습니다.

https://github.com/SOPT-all/35-COLLABORATION-SERVER-KORAILTALK/blob/c461c2633fb9dca677e39a8821e671a1aa911a44/src/main/java/com/korailtalk/server/api/common/exception/GlobalExceptionHandler.java#L8-L15


