### PR TITLE
[FEAT] : 좌석 선택 API 구현

### DIFF
--- a/src/main/java/com/korailtalk/server/api/common/enums/ErrorStatus.java
+++ b/src/main/java/com/korailtalk/server/api/common/enums/ErrorStatus.java
@@ -16,7 +16,8 @@ public enum ErrorStatus {
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "아이디에 해당하는 유저를 찾을 수 없습니다."),
     NOT_FOUND_TICKET(HttpStatus.NOT_FOUND, "아이디에 해당하는 티켓을 찾을 수 없습니다."),
     NOT_FOUND_TRAIN(HttpStatus.NOT_FOUND, "시간표에 해당하는 열차를 찾을 수 없습니다."),
-    NOT_FOUND_TIMETABLE(HttpStatus.NOT_FOUND, "아이디에 해당하는 시간표를 찾을 수 없습니다.");
+    NOT_FOUND_TIMETABLE(HttpStatus.NOT_FOUND, "아이디에 해당하는 시간표를 찾을 수 없습니다."),
+    NOT_FOUND_SEAT(HttpStatus.NOT_FOUND, "아이디에 해당하는 좌석을 찾을 수 없습니다");
 
     private final HttpStatus httpStatus;
 

--- a/src/main/java/com/korailtalk/server/api/seat/controller/SeatController.java
+++ b/src/main/java/com/korailtalk/server/api/seat/controller/SeatController.java
@@ -1,4 +1,27 @@
 package com.korailtalk.server.api.seat.controller;
 
+import com.korailtalk.server.api.common.dto.APISuccessResponse;
+import com.korailtalk.server.api.seat.dto.request.SeatSelectRequest;
+import com.korailtalk.server.api.seat.dto.response.SeatSelectResponse;
+import com.korailtalk.server.api.seat.service.SeatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
 public class SeatController {
+
+    private final SeatService seatService;
+
+    @PostMapping("/seats")
+    public ResponseEntity<APISuccessResponse<SeatSelectResponse>> selectSeat(
+            @RequestHeader final Long userId,
+            @RequestBody final SeatSelectRequest seatSelectRequest
+            ){
+        return APISuccessResponse.of(HttpStatus.OK,seatService.selectSeat(userId, seatSelectRequest));
+    }
+
 }

--- a/src/main/java/com/korailtalk/server/api/seat/dto/request/SeatSelectRequest.java
+++ b/src/main/java/com/korailtalk/server/api/seat/dto/request/SeatSelectRequest.java
@@ -1,4 +1,10 @@
 package com.korailtalk.server.api.seat.dto.request;
 
-public record SeatSelectRequest() {
+public record SeatSelectRequest(
+        boolean isAuto,
+        long coachId,
+        long seatId,
+        long timetableId,
+        int price
+) {
 }

--- a/src/main/java/com/korailtalk/server/api/seat/dto/response/SeatSelectResponse.java
+++ b/src/main/java/com/korailtalk/server/api/seat/dto/response/SeatSelectResponse.java
@@ -1,0 +1,9 @@
+package com.korailtalk.server.api.seat.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record SeatSelectResponse(
+        long ticketId
+) {
+}

--- a/src/main/java/com/korailtalk/server/api/seat/service/SeatService.java
+++ b/src/main/java/com/korailtalk/server/api/seat/service/SeatService.java
@@ -1,0 +1,74 @@
+package com.korailtalk.server.api.seat.service;
+
+import com.korailtalk.server.api.common.enums.ErrorStatus;
+import com.korailtalk.server.api.common.exception.NotFoundException;
+import com.korailtalk.server.api.seat.dto.request.SeatSelectRequest;
+import com.korailtalk.server.api.seat.dto.response.SeatSelectResponse;
+import com.korailtalk.server.db.coach.repository.CoachRepository;
+import com.korailtalk.server.db.seat.entity.Seat;
+import com.korailtalk.server.db.seat.repository.SeatRepository;
+import com.korailtalk.server.db.ticket.entity.Ticket;
+import com.korailtalk.server.db.ticket.repository.TicketRepository;
+import com.korailtalk.server.db.timetable.repository.TimetableRepository;
+import com.korailtalk.server.db.user.entity.User;
+import com.korailtalk.server.db.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SeatService {
+
+    private final TicketRepository ticketRepository;
+    private final UserRepository userRepository;
+    private final SeatRepository seatRepository;
+    private final TimetableRepository timetableRepository;
+    private final CoachRepository coachRepository;
+
+    public SeatSelectResponse selectSeat(Long userId, SeatSelectRequest seatSelectRequest){
+        final User user = userRepository.findById(userId).orElseThrow(
+                () -> new NotFoundException(ErrorStatus.NOT_FOUND_USER)
+        );
+
+        Long finalTicketId;
+
+        if (seatSelectRequest.isAuto()) {
+            Ticket newTicket = Ticket.builder()
+                    .seat(seatRepository.findById(seatSelectRequest.seatId()).orElseThrow(
+                            () -> new NotFoundException(ErrorStatus.NOT_FOUND_SEAT)))
+                    .price(seatSelectRequest.price())
+                    .ticketConfirm(false)
+                    .timetable(timetableRepository.findById(seatSelectRequest.timetableId()).orElseThrow(
+                            () -> new NotFoundException(ErrorStatus.NOT_FOUND_TIMETABLE)))
+                    .coach(coachRepository.findById(seatSelectRequest.coachId()).orElseThrow(
+                            () -> new NotFoundException(ErrorStatus.NOT_FOUND_TIMETABLE)))
+                    .build();
+
+            Ticket savedTicket = ticketRepository.save(newTicket);
+            finalTicketId = savedTicket.getId();
+        } else {
+
+            // 1. CoachId 받아오기
+            // 2. 해당 CoachID 중에 isSold == false 인 것 중에 첫번째 반환
+            Seat seat = seatRepository.findFirstBySeatSoldFalseAndCoachIdOrderByIdAsc(seatSelectRequest.coachId());
+                Ticket randomTicket = Ticket.builder()
+                        .seat(seat)
+                        .price(seatSelectRequest.price())
+                        .ticketConfirm(false)
+                        .timetable(timetableRepository.findById(seatSelectRequest.timetableId()).orElseThrow(
+                                () -> new NotFoundException(ErrorStatus.NOT_FOUND_TIMETABLE)))
+                        .coach(coachRepository.findById(seatSelectRequest.coachId()).orElseThrow(
+                                () -> new NotFoundException(ErrorStatus.NOT_FOUND_TIMETABLE)))
+                        .build();
+
+            Ticket savedTicket = ticketRepository.save(randomTicket);
+            finalTicketId = savedTicket.getId();
+        }
+
+
+        return SeatSelectResponse.builder()
+                .ticketId(finalTicketId)
+                .build();
+
+    }
+}

--- a/src/main/java/com/korailtalk/server/db/BaseTimeEntity.java
+++ b/src/main/java/com/korailtalk/server/db/BaseTimeEntity.java
@@ -15,6 +15,6 @@ import java.time.LocalDateTime;
 public class BaseTimeEntity {
 
     @CreatedDate
-    @Column(name = "created_at", updatable = false, nullable = false)
+    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/korailtalk/server/db/seat/repository/SeatRepository.java
+++ b/src/main/java/com/korailtalk/server/db/seat/repository/SeatRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 @Repository
 public interface SeatRepository extends JpaRepository<Seat, Long> {
     List<Seat> findByCoachId(Long coachId);
+    Seat findFirstBySeatSoldFalseAndCoachIdOrderByIdAsc(Long coachId);
 }

--- a/src/main/java/com/korailtalk/server/db/ticket/entity/Ticket.java
+++ b/src/main/java/com/korailtalk/server/db/ticket/entity/Ticket.java
@@ -41,10 +41,10 @@ public class Ticket extends BaseTimeEntity {
     @Builder
     public Ticket(final Timetable timetable, final Seat seat, final Coach coach, final int price, final boolean ticketConfirm) {
         this.timetable = timetable;
-        this.seat = seat;
+        this.seat = seat; //
         this.coach = coach;
-        this.price = price;
-        this.ticketConfirm = ticketConfirm;
+        this.price = price; //
+        this.ticketConfirm = ticketConfirm; //
     }
 
     public void updatePrice(final int totalPrice) {

--- a/src/main/java/com/korailtalk/server/db/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/korailtalk/server/db/ticket/repository/TicketRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
+    //Optional<Ticket> findFirstByTicketConfirmFalseOrderByIdAsc();
 }


### PR DESCRIPTION
# ⭐️ 관련이슈
#17 

# ⭐️ 구현사항

## 🔧 좌석 선택 API 구현

🍃 Controller 에 POST 추가
https://github.com/SOPT-all/35-COLLABORATION-SERVER-KORAILTALK/blob/36a994dadd18f5d8503e3afe5a51cf77053c4c76/src/main/java/com/korailtalk/server/api/seat/controller/SeatController.java#L19-L25

<br>

🍃 request, response 노션에 맞게 작성했습니다!

<br>

🍃 isAuto() == true일 땐, 입력 받은 seatId, price로 티켓 생성
https://github.com/SOPT-all/35-COLLABORATION-SERVER-KORAILTALK/blob/36a994dadd18f5d8503e3afe5a51cf77053c4c76/src/main/java/com/korailtalk/server/api/seat/service/SeatService.java#L35

🍃 isAuto() == false일 땐, 랜덤 seatId과 입력 받은 price로 티켓 생성
- 랜덤 seatId : isSold가 false인 것 중 제일 첫번째 값을 가져
https://github.com/SOPT-all/35-COLLABORATION-SERVER-KORAILTALK/blob/36a994dadd18f5d8503e3afe5a51cf77053c4c76/src/main/java/com/korailtalk/server/api/seat/service/SeatService.java#L53

